### PR TITLE
Fix CI workflow environment issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,13 +153,21 @@ jobs:
               jobs -l
               ps aux | grep -v grep | grep node || echo "No Node.js processes found"
               echo "🔍 Port 3000 status:"
-              netstat -tlnp | grep :3000 || echo "Port 3000 not listening"
+              ss -tlnp | grep :3000 || echo "Port 3000 not listening"
               kill $APP_PID 2>/dev/null || true
               exit 1
             fi
           done
+          echo "APP_PID=$APP_PID" >> "$GITHUB_ENV"
         env:
           PORT: 3000
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_APP_NAME: ${{ secrets.NEXT_PUBLIC_APP_NAME }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
 
       - name: Create ZAP reports directory
         run: mkdir -p zap-reports
@@ -245,10 +253,14 @@ jobs:
           else
             echo "ℹ️ ZAP XML report not found - scan may not have completed"
             echo "🔍 Available files in zap-reports:"
-            ls -la zap-reports/ || echo "ZAP reports directory not found"
-            echo "ℹ️ This is acceptable in some CI environments"
-          fi
-        continue-on-error: true
+          ls -la zap-reports/ || echo "ZAP reports directory not found"
+          echo "ℹ️ This is acceptable in some CI environments"
+        fi
+      continue-on-error: true
+
+      - name: Stop application
+        if: always() && env.APP_PID
+        run: kill $APP_PID || true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
@@ -289,5 +301,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: ./
-          vercel-args: '--prod' 
+          working-directory: ./          vercel-args: '--prod' 


### PR DESCRIPTION
## Summary
- pass required secrets to `npm run start` step
- use `ss` instead of `netstat` when checking for open port
- store APP_PID for later use and add step to kill the server

## Testing
- `npm test -- --runTestsByPath` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e023868b883319bd01aaa1d02bcb4