### PR TITLE
Fix supabase mock chains in integration tests

### DIFF
--- a/src/__tests__/assignment-system-integration-fixed.test.ts
+++ b/src/__tests__/assignment-system-integration-fixed.test.ts
@@ -326,11 +326,13 @@ describe('Assignment System Integration Tests (Fixed)', () => {
           select: jest.fn(() => ({
             eq: jest.fn(() => ({
               order: jest.fn(() => ({
-                range: jest.fn().mockResolvedValue({
-                  data: mockAssignments,
-                  error: null,
-                  count: 2,
-                }),
+                range: jest.fn(() => ({
+                  select: jest.fn().mockResolvedValue({
+                    data: mockAssignments,
+                    error: null,
+                    count: 2,
+                  }),
+                })),
               })),
             })),
           })),
@@ -374,11 +376,13 @@ describe('Assignment System Integration Tests (Fixed)', () => {
         const mockFrom = {
           update: jest.fn(() => ({
             eq: jest.fn(() => ({
-              select: jest.fn(() => ({
-                single: jest.fn().mockResolvedValue({
-                  data: mockUpdatedAssignment,
-                  error: null,
-                }),
+              eq: jest.fn(() => ({
+                select: jest.fn(() => ({
+                  single: jest.fn().mockResolvedValue({
+                    data: mockUpdatedAssignment,
+                    error: null,
+                  }),
+                })),
               })),
             })),
           })),
@@ -540,11 +544,13 @@ describe('Assignment System Integration Tests (Fixed)', () => {
         })),
         update: jest.fn(() => ({
           eq: jest.fn(() => ({
-            select: jest.fn(() => ({
-              single: jest.fn().mockResolvedValue({
-                data: { ...mockCreatedAssignment, status: 'published' },
-                error: null,
-              }),
+            eq: jest.fn(() => ({
+              select: jest.fn(() => ({
+                single: jest.fn().mockResolvedValue({
+                  data: { ...mockCreatedAssignment, status: 'published' },
+                  error: null,
+                }),
+              })),
             })),
           })),
         })),

--- a/src/__tests__/assignment-system-integration.test.ts
+++ b/src/__tests__/assignment-system-integration.test.ts
@@ -262,11 +262,13 @@ describe('Assignment System Integration Tests', () => {
           eq: jest.fn().mockReturnThis(),
           order: jest.fn().mockReturnThis(),
           limit: jest.fn().mockReturnThis(),
-          range: jest.fn().mockResolvedValue({
-            data: mockAssignments,
-            error: null,
-            count: 2,
-          }),
+          range: jest.fn(() => ({
+            select: jest.fn().mockResolvedValue({
+              data: mockAssignments,
+              error: null,
+              count: 2,
+            }),
+          })),
         };
 
         mockSupabaseFrom.mockReturnValue(mockChain);
@@ -290,13 +292,18 @@ describe('Assignment System Integration Tests', () => {
         };
 
         const mockChain = {
-          update: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          select: jest.fn().mockReturnThis(),
-          single: jest.fn().mockResolvedValue({
-            data: { id: 'assignment-123', ...updateData },
-            error: null,
-          }),
+          update: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                select: jest.fn(() => ({
+                  single: jest.fn().mockResolvedValue({
+                    data: { id: 'assignment-123', ...updateData },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          })),
         };
 
         mockSupabaseFrom.mockReturnValue(mockChain);
@@ -447,17 +454,22 @@ describe('Assignment System Integration Tests', () => {
 
       // 2. Update assignment status to published
       const updateMockChain = {
-        update: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue({
-          data: {
-            id: 'assignment-e2e',
-            ...newAssignment,
-            status: 'published',
-          },
-          error: null,
-        }),
+        update: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              select: jest.fn(() => ({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'assignment-e2e',
+                    ...newAssignment,
+                    status: 'published',
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          })),
+        })),
       };
 
       mockSupabaseFrom.mockReturnValue(updateMockChain);

--- a/src/__tests__/attendance-system-integration.test.ts
+++ b/src/__tests__/attendance-system-integration.test.ts
@@ -247,11 +247,13 @@ describe('Attendance System Integration Tests', () => {
           eq: jest.fn().mockReturnThis(),
           order: jest.fn().mockReturnThis(),
           limit: jest.fn().mockReturnThis(),
-          range: jest.fn().mockResolvedValue({
-            data: mockAttendanceRecords,
-            error: null,
-            count: 2,
-          }),
+          range: jest.fn(() => ({
+            select: jest.fn().mockResolvedValue({
+              data: mockAttendanceRecords,
+              error: null,
+              count: 2,
+            }),
+          })),
         };
 
         mockSupabaseFrom.mockReturnValue(mockChain);
@@ -295,11 +297,13 @@ describe('Attendance System Integration Tests', () => {
           lte: jest.fn().mockReturnThis(),
           order: jest.fn().mockReturnThis(),
           limit: jest.fn().mockReturnThis(),
-          range: jest.fn().mockResolvedValue({
-            data: mockAttendanceRecords,
-            error: null,
-            count: 2,
-          }),
+          range: jest.fn(() => ({
+            select: jest.fn().mockResolvedValue({
+              data: mockAttendanceRecords,
+              error: null,
+              count: 2,
+            }),
+          })),
         };
 
         mockSupabaseFrom.mockReturnValue(mockChain);
@@ -328,13 +332,18 @@ describe('Attendance System Integration Tests', () => {
         };
 
         const mockChain = {
-          update: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          select: jest.fn().mockReturnThis(),
-          single: jest.fn().mockResolvedValue({
-            data: { id: 'attendance-123', ...updateData },
-            error: null,
-          }),
+          update: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                select: jest.fn(() => ({
+                  single: jest.fn().mockResolvedValue({
+                    data: { id: 'attendance-123', ...updateData },
+                    error: null,
+                  }),
+                })),
+              })),
+            })),
+          })),
         };
 
         mockSupabaseFrom.mockReturnValue(mockChain);

--- a/src/__tests__/integration-db-lightweight.test.ts
+++ b/src/__tests__/integration-db-lightweight.test.ts
@@ -31,6 +31,7 @@ const mockQueryChain = {
   update: jest.fn().mockReturnThis(),
   delete: jest.fn().mockReturnThis(),
   eq: jest.fn().mockReturnThis(),
+  range: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
   single: jest.fn(),
 };


### PR DESCRIPTION
## Summary
- support `.range` in the lightweight integration mock
- correct query builder chains in assignment and attendance integration tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853cd0f1b0833187d2622a63eb7c3a